### PR TITLE
Update cluster-backup to work with Workbench running in a single pod

### DIFF
--- a/cluster-backup.yaml
+++ b/cluster-backup.yaml
@@ -2,46 +2,28 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: cluster-backup
+  name: backup-shell
+  namespace: workbench
   labels:
-    app: cluster-backup
+    app: backup-shell
 spec:
   template:
     metadata:
+      name: backup-shell
+      namespace: workbench
       labels:
-        name: cluster-backup
+        name: backup-shell
     spec:
       hostNetwork: true
       containers:
         - image: ndslabs/cluster-backup:latest
           imagePullPolicy: Always
-          name: cluster-backup
+          name: backup
+          stdin: true
+          tty: true
+          command: [ "/bin/bash" ]
           env:
            - name: ETCD_HOST
-             value: $(NDSLABS_ETCD_SERVICE_HOST)
+             value: $(WORKBENCH_ETCD_SERVICE_HOST)
            - name: ETCD_PORT
-             value: $(NDSLABS_ETCD_SERVICE_PORT)
-           - name: BACKUP_SRC
-             value: "/var/glfs"
-           - name: BACKUP_DEST
-             value: /ndsbackup
-           - name: BACKUP_HOST
-             value: 
-           - name: BACKUP_USER
-             value: 
-           - name: BACKUP_KEY
-             value: "/etc/backup-key/ssh-privatekey"
-          volumeMounts:
-            - name: backup-src
-              mountPath: /var/glfs
-            - name: backup-key
-              readOnly: true
-              mountPath: /etc/backup-key/
-      volumes:
-        - name: backup-src
-          hostPath:
-              path: /var/glfs
-        - name: backup-key
-          secret:
-            secretName: backup-key
-            defaultMode: 0600
+             value: $(WORKBENCH_ETCD_SERVICE_PORT)

--- a/workbench-etcd.service.yaml
+++ b/workbench-etcd.service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: workbench
+  name: workbench-etcd
+  namespace: workbench
+spec:
+  ports:
+  - name: etcd
+    port: 4001
+    protocol: TCP
+  selector:
+    component: workbench


### PR DESCRIPTION
### Problem
Our recent changes to etcd and the Workbench service to run as a single pod is problematic for the backup container, which relied on the injected envvars from the Kubernetes Service to access etcd to back up its data.

### Approach
* Added a service to expose etcd internally
* Changed `cluster-backup` to `cluster-shell`, an interactive environment for running `etcd-dump` or other cluster backup utilities

### How to Test
1. Deploy Workbench via helm-chart
2. `kubectl create -f workbench-etcd.service.yaml`
3. `kubectl create -f cluster-backup.yaml`
4. `kubectl get pods -n workbench --watch`
5. ` kubectl exec -it <name-of-backup-shell-pod> -n workbench -- bash`
6. `etcd-dump dump --etcd=http://$(ETCD_HOST):${ETCD_PORT} etcd-backup.json
    * You should see the `etcd-backup.json` contains a backup of the chosen etcd